### PR TITLE
Updated ExpressionExtensions to support decimal types

### DIFF
--- a/TestStack.BDDfy/Scanners/StepScanners/Fluent/ExpressionExtensions.cs
+++ b/TestStack.BDDfy/Scanners/StepScanners/Fluent/ExpressionExtensions.cs
@@ -172,6 +172,7 @@ namespace TestStack.BDDfy.Scanners.StepScanners.Fluent
             else
             {
                 if (constantExpression.Type == typeof(string) ||
+					constantExpression.Type == typeof(decimal) ||
                     constantExpression.Type.IsPrimitive ||
                     constantExpression.Type.IsEnum ||
                     constantExpression.Value == null)


### PR DESCRIPTION
this patch fixes the following scenario with decimals as parameters

this.Given(_ => _AndGivenAmount(2), "Given the amount of {0}").BDDfy();
