### PR TITLE
Because step order enforcement has been removed on fluent API we need to...

### DIFF
--- a/TestStack.BDDfy.Tests/Configuration/TestRunnerTests.cs
+++ b/TestStack.BDDfy.Tests/Configuration/TestRunnerTests.cs
@@ -98,11 +98,11 @@ namespace TestStack.BDDfy.Tests.Configuration
             public void FailingThenDoesNotStopThePipelineWithReflectiveAPI()
             {
                 var testRun = new ScenarioWithFailingThen().LazyBDDfy();
-                Verify(testRun);
+                Verify(testRun, Result.Passed);
             }
 
             [Test]
-            public void FailingThenDoesNotStopThePipelineWithFluentAPI()
+            public void FailingThenDoesStopThePipelineWithFluentAPI()
             {
                 var testRun = new ScenarioWithFailingThen()
                     .Given(x => x.PassingGiven())
@@ -111,10 +111,10 @@ namespace TestStack.BDDfy.Tests.Configuration
                     .And(x => x.PassingAndThen())
                     .LazyBDDfy();
 
-                Verify(testRun);
+                Verify(testRun, Result.NotExecuted);
             }
 
-            private static void Verify(Engine testRun)
+            private static void Verify(Engine testRun, Result lastStepResult)
             {
                 Assert.Throws<Exception>(() => testRun.Run());
                 var scenario = testRun.Story.Scenarios.First();
@@ -128,7 +128,7 @@ namespace TestStack.BDDfy.Tests.Configuration
                 Assert.AreEqual(ExecutionOrder.Transition, steps[1].ExecutionOrder);
                 Assert.AreEqual(Result.Failed, steps[2].Result);
                 Assert.AreEqual(ExecutionOrder.Assertion, steps[2].ExecutionOrder);
-                Assert.AreEqual(Result.Passed, steps[3].Result);
+                Assert.AreEqual(lastStepResult, steps[3].Result);
                 Assert.AreEqual(ExecutionOrder.ConsecutiveAssertion, steps[3].ExecutionOrder);
             }
         }

--- a/TestStack.BDDfy.Tests/Processors/TestRunnerTests.cs
+++ b/TestStack.BDDfy.Tests/Processors/TestRunnerTests.cs
@@ -25,7 +25,7 @@ namespace TestStack.BDDfy.Tests.Processors
             Action<object> action = o => actualValue = ExampleValue;
             var steps = new List<Step> { new Step(action, new StepTitle("A Step"), true, ExecutionOrder.Initialize, true) };
 
-            var scenarioWithExample = new Scenario("id", this, steps, "Scenario Text", exampleTable);
+            var scenarioWithExample = new Scenario("id", this, steps, true, "Scenario Text", exampleTable);
             var story = new Story(new StoryMetadata(typeof(TestRunnerTests), new StoryNarrativeAttribute()),
                 new[] { scenarioWithExample });
 

--- a/TestStack.BDDfy.Tests/Reporters/Html/ClassicReportBuilderTests.ShouldProduceExpectedHtml.approved.txt
+++ b/TestStack.BDDfy.Tests/Reporters/Html/ClassicReportBuilderTests.ShouldProduceExpectedHtml.approved.txt
@@ -104,7 +104,7 @@ body{margin:0;padding:0;padding-bottom:40px;max-width:100%;background-color:#fff
                     <li class='step Failed  Assertion canToggle' data-toggle-target='step-3-3' >
                       <span>Then no money is dispensed [Exception Message: 'Boom']</span>
                       <div class='step FailedException' id='step-3-3'>
-                        <code>   at TestStack.BDDfy.Tests.Reporters.ReportTestData.GetScenarios(Boolean includeFailingScenario, Boolean includeExamples) in ...\ReportTestData.cs:line 90</code>
+                        <code>   at TestStack.BDDfy.Tests.Reporters.ReportTestData.GetScenarios(Boolean includeFailingScenario, Boolean includeExamples) in ...\ReportTestData.cs:line 89</code>
                       </div>
                     </li>
                   </ul>

--- a/TestStack.BDDfy.Tests/Reporters/Html/ClassicReportBuilderTests.ShouldProduceExpectedHtmlWithExamples.approved.txt
+++ b/TestStack.BDDfy.Tests/Reporters/Html/ClassicReportBuilderTests.ShouldProduceExpectedHtmlWithExamples.approved.txt
@@ -113,7 +113,7 @@ body{margin:0;padding:0;padding-bottom:40px;max-width:100%;background-color:#fff
                           <td>
                             <span class='canToggle' data-toggle-target='step-1-19'>Boom</span>
                             <div class='step' id='step-1-19'>
-                              <code>   at TestStack.BDDfy.Tests.Reporters.ReportTestData.GetScenarios(Boolean includeFailingScenario, Boolean includeExamples) in ...\ReportTestData.cs:line 113</code>
+                              <code>   at TestStack.BDDfy.Tests.Reporters.ReportTestData.GetScenarios(Boolean includeFailingScenario, Boolean includeExamples) in ...\ReportTestData.cs:line 112</code>
                             </div>
                           </td>
                         </tr>

--- a/TestStack.BDDfy.Tests/Reporters/Html/MetroReportBuilderTests.ShouldProduceExpectedHtmlWithExamples.approved.txt
+++ b/TestStack.BDDfy.Tests/Reporters/Html/MetroReportBuilderTests.ShouldProduceExpectedHtmlWithExamples.approved.txt
@@ -124,7 +124,7 @@ html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abb
                           <td>
                             <span class='canToggle' data-toggle-target='step-1-19'>Boom</span>
                             <div class='step FailedException' id='step-1-19'>
-                              <code>   at TestStack.BDDfy.Tests.Reporters.ReportTestData.GetScenarios(Boolean includeFailingScenario, Boolean includeExamples) in ...\ReportTestData.cs:line 113</code>
+                              <code>   at TestStack.BDDfy.Tests.Reporters.ReportTestData.GetScenarios(Boolean includeFailingScenario, Boolean includeExamples) in ...\ReportTestData.cs:line 112</code>
                             </div>
                           </td>
                         </tr>

--- a/TestStack.BDDfy.Tests/Reporters/ReportTestData.cs
+++ b/TestStack.BDDfy.Tests/Reporters/ReportTestData.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace TestStack.BDDfy.Tests.Reporters
 {
@@ -8,13 +7,13 @@ namespace TestStack.BDDfy.Tests.Reporters
 
     public class ReportTestData
     {
-        private int _idCount = 0;
+        private int _idCount;
 
         public IEnumerable<Story> CreateTwoStoriesEachWithOneFailingScenarioAndOnePassingScenarioWithThreeStepsOfFiveMilliseconds()
         {
             var storyMetadata1 = new StoryMetadata(typeof(RegularAccountHolderStory), "As a person", "I want ice cream", "So that I can be happy", "Happiness");
             var storyMetadata2 = new StoryMetadata(typeof(GoldAccountHolderStory), "As an account holder", "I want to withdraw cash", "So that I can get money when the bank is closed", "Account holder withdraws cash");
-            var stories = new List<Story>()
+            var stories = new List<Story>
             {
                 new Story(storyMetadata1, GetScenarios(false, false)),
                 new Story(storyMetadata2, GetScenarios(true, false))
@@ -30,7 +29,7 @@ namespace TestStack.BDDfy.Tests.Reporters
 
             const StoryMetadata testThatReportWorksWithNoStory = null;
 
-            var stories = new List<Story>()
+            var stories = new List<Story>
             {
                 new Story(storyMetadata1, GetOneOfEachScenarioResult()),
                 new Story(storyMetadata2, GetOneOfEachScenarioResult()),
@@ -48,16 +47,16 @@ namespace TestStack.BDDfy.Tests.Reporters
 
             const StoryMetadata testThatReportWorksWithNoStory = null;
 
-            var stories = new List<Story>()
+            var stories = new List<Story>
             {
-                new Story(storyMetadata1, new Scenario(typeof(HappyPathScenario), GetHappyExecutionSteps(), "Happy Path Scenario [for Happiness]")),
-                new Story(storyMetadata1, new Scenario(typeof(SadPathScenario), GetFailingExecutionSteps(), "Sad Path Scenario [for Happiness]")),
-                new Story(storyMetadata1, new Scenario(typeof(SadPathScenario), GetInconclusiveExecutionSteps(), "Inconclusive Scenario [for Happiness]")),
-                new Story(storyMetadata1, new Scenario(typeof(SadPathScenario), GetNotImplementedExecutionSteps(), "Not Implemented Scenario [for Happiness]")),
-                new Story(testThatReportWorksWithNoStory, new Scenario(typeof(HappyPathScenario), GetHappyExecutionSteps(), "Happy Path Scenario [with no story]")),
-                new Story(testThatReportWorksWithNoStory, new Scenario(typeof(SadPathScenario), GetFailingExecutionSteps(), "Sad Path Scenario [with no story]")),
-                new Story(testThatReportWorksWithNoStory, new Scenario(typeof(SadPathScenario), GetInconclusiveExecutionSteps(), "Inconclusive Scenario [with no story]")),
-                new Story(testThatReportWorksWithNoStory, new Scenario(typeof(SadPathScenario), GetNotImplementedExecutionSteps(), "Not Implemented Scenario [with no story]")),
+                new Story(storyMetadata1, new Scenario(typeof(HappyPathScenario), GetHappyExecutionSteps(), false, "Happy Path Scenario [for Happiness]")),
+                new Story(storyMetadata1, new Scenario(typeof(SadPathScenario), GetFailingExecutionSteps(), false, "Sad Path Scenario [for Happiness]")),
+                new Story(storyMetadata1, new Scenario(typeof(SadPathScenario), GetInconclusiveExecutionSteps(), false, "Inconclusive Scenario [for Happiness]")),
+                new Story(storyMetadata1, new Scenario(typeof(SadPathScenario), GetNotImplementedExecutionSteps(), false, "Not Implemented Scenario [for Happiness]")),
+                new Story(testThatReportWorksWithNoStory, new Scenario(typeof(HappyPathScenario), GetHappyExecutionSteps(), false, "Happy Path Scenario [with no story]")),
+                new Story(testThatReportWorksWithNoStory, new Scenario(typeof(SadPathScenario), GetFailingExecutionSteps(), false, "Sad Path Scenario [with no story]")),
+                new Story(testThatReportWorksWithNoStory, new Scenario(typeof(SadPathScenario), GetInconclusiveExecutionSteps(), false, "Inconclusive Scenario [with no story]")),
+                new Story(testThatReportWorksWithNoStory, new Scenario(typeof(SadPathScenario), GetNotImplementedExecutionSteps(), false, "Not Implemented Scenario [with no story]")),
                 new Story(storyMetadata2, GetScenarios(true, true)),
                 new Story(storyMetadata3, GetScenarios(false, true)),
             };
@@ -119,26 +118,26 @@ namespace TestStack.BDDfy.Tests.Reporters
                 }
                 return new List<Scenario>
                 {
-                    new Scenario(exampleId, typeof(ExampleScenario), GetExampleExecutionSteps(), "Example Scenario", exampleTable.ElementAt(0)),
-                    new Scenario(exampleId, typeof(ExampleScenario), exampleExecutionSteps, "Example Scenario", exampleTable.ElementAt(1))
+                    new Scenario(exampleId, typeof(ExampleScenario), GetExampleExecutionSteps(), false, "Example Scenario", exampleTable.ElementAt(0)),
+                    new Scenario(exampleId, typeof(ExampleScenario), exampleExecutionSteps, false, "Example Scenario", exampleTable.ElementAt(1))
                 }.ToArray();
             }
 
             return new List<Scenario>
                        {
-                           new Scenario(typeof(HappyPathScenario), GetHappyExecutionSteps(), "Happy Path Scenario"),
-                           new Scenario(typeof(SadPathScenario), sadExecutionSteps, "Sad Path Scenario")
+                           new Scenario(typeof(HappyPathScenario), GetHappyExecutionSteps(), false, "Happy Path Scenario"),
+                           new Scenario(typeof(SadPathScenario), sadExecutionSteps, false, "Sad Path Scenario")
                        }.ToArray();
         }
 
         private Scenario[] GetOneOfEachScenarioResult()
         {
-            var scenarios = new List<Scenario>()
+            var scenarios = new List<Scenario>
             {
-                new Scenario(typeof(HappyPathScenario), GetHappyExecutionSteps(), "Happy Path Scenario"),
-                new Scenario(typeof(SadPathScenario), GetSadExecutionSteps(), "Sad Path Scenario"),
-                new Scenario(typeof(SadPathScenario), GetInconclusiveExecutionSteps(), "Inconclusive Scenario"),
-                new Scenario(typeof(SadPathScenario), GetNotImplementedExecutionSteps(), "Not Implemented Scenario")
+                new Scenario(typeof(HappyPathScenario), GetHappyExecutionSteps(), false, "Happy Path Scenario"),
+                new Scenario(typeof(SadPathScenario), GetSadExecutionSteps(), false, "Sad Path Scenario"),
+                new Scenario(typeof(SadPathScenario), GetInconclusiveExecutionSteps(), false, "Inconclusive Scenario"),
+                new Scenario(typeof(SadPathScenario), GetNotImplementedExecutionSteps(), false, "Not Implemented Scenario")
             };
 
             // override specific step results - ideally this class could be refactored to provide  objectmother/builder interface

--- a/TestStack.BDDfy/Processors/TestRunner.cs
+++ b/TestStack.BDDfy/Processors/TestRunner.cs
@@ -21,7 +21,7 @@
                     if (executor.ExecuteStep(executionStep) == Result.Passed) 
                         continue;
 
-                    if (Configuration.Configurator.Processors.TestRunner.StopExecutionOnFailingThen || !executionStep.Asserts)
+                    if (!scenario.CanContinueExecutionOnStepFail || Configuration.Configurator.Processors.TestRunner.StopExecutionOnFailingThen || !executionStep.Asserts)
                         break;
                 }
 

--- a/TestStack.BDDfy/Scanners/ScenarioScanners/FluentScenarioScanner.cs
+++ b/TestStack.BDDfy/Scanners/ScenarioScanners/FluentScenarioScanner.cs
@@ -23,10 +23,10 @@ namespace TestStack.BDDfy
             {
                 var scenarioId = Configurator.IdGenerator.GetScenarioId();
                 return testContext.Examples.Select(example =>
-                    new Scenario(scenarioId, testContext.TestObject, CloneSteps(_steps), scenarioText, example));
+                    new Scenario(scenarioId, testContext.TestObject, CloneSteps(_steps), false, scenarioText, example));
             }
 
-            return new[] { new Scenario(testContext.TestObject, _steps, scenarioText) };
+            return new[] { new Scenario(testContext.TestObject, _steps, false, scenarioText) };
         }
 
         private List<Step> CloneSteps(IEnumerable<Step> steps)

--- a/TestStack.BDDfy/Scanners/ScenarioScanners/ReflectiveScenarioScanner.cs
+++ b/TestStack.BDDfy/Scanners/ScenarioScanners/ReflectiveScenarioScanner.cs
@@ -34,7 +34,7 @@ namespace TestStack.BDDfy
                 scenarioTitle = _scenarioTitle ?? GetScenarioText(scenarioType);
 
                 var orderedSteps = steps.OrderBy(o => o.ExecutionOrder).ThenBy(o => o.ExecutionSubOrder).ToList();
-                yield return new Scenario(testContext.TestObject, orderedSteps, scenarioTitle);
+                yield return new Scenario(testContext.TestObject, orderedSteps, true, scenarioTitle);
                 yield break;
             }
 
@@ -47,7 +47,7 @@ namespace TestStack.BDDfy
             {
                 var steps = ScanScenarioForSteps(testContext, example);
                 var orderedSteps = steps.OrderBy(o => o.ExecutionOrder).ThenBy(o => o.ExecutionSubOrder).ToList();
-                yield return new Scenario(scenarioId, testContext.TestObject, orderedSteps, scenarioTitle, example);
+                yield return new Scenario(scenarioId, testContext.TestObject, orderedSteps, true, scenarioTitle, example);
             }
         }
 

--- a/TestStack.BDDfy/Scenario.cs
+++ b/TestStack.BDDfy/Scenario.cs
@@ -7,19 +7,21 @@ namespace TestStack.BDDfy
 {
     public class Scenario
     {
-        public Scenario(object testObject, List<Step> steps, string scenarioText)
+        public Scenario(object testObject, List<Step> steps, bool canContinueExecutionOnStepFail, string scenarioText)
         {
             TestObject = testObject;
             Steps = steps;
+            CanContinueExecutionOnStepFail = canContinueExecutionOnStepFail;
             Title = scenarioText;
             Id = Configurator.IdGenerator.GetScenarioId();
         }
 
-        public Scenario(string id, object testObject, List<Step> steps, string scenarioText, Example example)
+        public Scenario(string id, object testObject, List<Step> steps, bool canContinueExecutionOnStepFail, string scenarioText, Example example)
         {
             Id = id;
             TestObject = testObject;
             Steps = steps;
+            CanContinueExecutionOnStepFail = canContinueExecutionOnStepFail;
             Title = scenarioText;
             Example = example;
         }
@@ -30,6 +32,7 @@ namespace TestStack.BDDfy
         public TimeSpan Duration { get { return new TimeSpan(Steps.Sum(x => x.Duration.Ticks)); } }
         public object TestObject { get; internal set; }
         public List<Step> Steps { get; private set; }
+        public bool CanContinueExecutionOnStepFail { get; private set; }
 
         public Result Result
         {


### PR DESCRIPTION
... always stop execution when step fails
