### PR TITLE
Fixing issue with argument extractor not working when drilling into subj...

### DIFF
--- a/TestStack.BDDfy.Tests/Scanner/FluentScanner/ExpressionExtensionsTests.cs
+++ b/TestStack.BDDfy.Tests/Scanner/FluentScanner/ExpressionExtensionsTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using NUnit.Framework;
+using Shouldly;
 
 namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
 {
@@ -63,6 +64,15 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
             public void MethodWithInputs(ContainerType subContainer)
             {
 
+            }
+
+            public Bar Foo { get; set; }
+
+            public class Bar
+            {
+                public void Baz()
+                {
+                }
             }
         }
 
@@ -241,6 +251,13 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
         {
             var arguments = GetArguments(x => x.MethodWithInputs(GetNumberThree(), GetFooString()), new ClassUnderTest());
             AssertReturnedArguments(arguments, new object[] { 3, "Foo" });
+        }
+
+        [Test]
+        public void DeepPropertyCall()
+        {
+            var arguments = GetArguments(x => x.Foo.Baz(), new ClassUnderTest());
+            arguments.ShouldBeEmpty();
         }
 
         private string GetFooString()

--- a/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
+++ b/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
@@ -12,12 +12,32 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
         [Test]
         public void MethodCallInStepTitle()
         {
+            FooClass something = new FooClass();
             var story = this
                 .Given(_ => GivenWeMutateSomeState())
+                .When(_ => something.Sub.SomethingHappens())
                 .Then(_ => ThenTitleHas(AMethodCall()))
                 .BDDfy();
 
-            story.Scenarios.Single().Steps.ElementAt(1).Title.ShouldBe("Then title has Mutated state");
+            story.Scenarios.Single().Steps.ElementAt(2).Title.ShouldBe("Then title has Mutated state");
+        }
+
+        public class FooClass
+        {
+            public FooClass()
+            {
+                Sub = new BarClass();
+            }
+
+            public BarClass Sub { get; set; }
+        }
+
+        public class BarClass
+        {
+            public void SomethingHappens()
+            {
+                
+            }
         }
 
         private string AMethodCall()

--- a/TestStack.BDDfy/Scanners/StepScanners/Fluent/ExpressionExtensions.cs
+++ b/TestStack.BDDfy/Scanners/StepScanners/Fluent/ExpressionExtensions.cs
@@ -20,7 +20,7 @@ namespace TestStack.BDDfy
             if (methodCallExpression == null)
                 throw new InvalidOperationException("Please provide a *method call* lambda expression.");
 
-            return ExtractArguments(methodCallExpression, value);
+            return ExtractArguments(methodCallExpression, value, false);
         }
 
         public static IEnumerable<StepArgument> ExtractArguments<T>(this Expression<Func<T, Task>> expression, T value)
@@ -33,7 +33,7 @@ namespace TestStack.BDDfy
             if (methodCallExpression == null)
                 throw new InvalidOperationException("Please provide a *method call* lambda expression.");
 
-            return ExtractArguments(methodCallExpression, value);
+            return ExtractArguments(methodCallExpression, value, false);
         }
 
         private static IEnumerable<StepArgument> ExtractArguments<T>(Expression expression, T value)
@@ -71,13 +71,19 @@ namespace TestStack.BDDfy
         private static IEnumerable<StepArgument> Invoke(MethodCallExpression methodCallExpression, IEnumerable<StepArgument> args)
         {
             var constantExpression = methodCallExpression.Object as ConstantExpression;
+            var stepArguments = args.ToArray();
             if (constantExpression != null)
-                return new[] { new StepArgument(() => methodCallExpression.Method.Invoke(constantExpression.Value, args.Select(s => s.Value).ToArray())) };
+                return new[] { new StepArgument(() => methodCallExpression.Method.Invoke(constantExpression.Value, stepArguments.Select(s => s.Value).ToArray())) };
 
-            return new[] { new StepArgument(() => methodCallExpression.Method.Invoke(args.First().Value, args.Skip(1).Select(s => s.Value).ToArray())) };
+            return new[] { new StepArgument(() =>
+            {
+                var value = stepArguments.First().Value;
+                var parameters = stepArguments.Skip(1).Select(s => s.Value).ToArray();
+                return methodCallExpression.Method.Invoke(value, parameters);
+            }) };
         }
 
-        private static IEnumerable<StepArgument> ExtractArguments<T>(MethodCallExpression methodCallExpression, T value)
+        private static IEnumerable<StepArgument> ExtractArguments<T>(MethodCallExpression methodCallExpression, T value, bool extractArgsFromExpression = true)
         {
             var constants = new List<StepArgument>();
             foreach (var arg in methodCallExpression.Arguments)
@@ -85,7 +91,10 @@ namespace TestStack.BDDfy
                 constants.AddRange(ExtractArguments(arg, value));
             }
 
-            constants.AddRange(ExtractArguments(methodCallExpression.Object, value));
+            if (extractArgsFromExpression)
+            {
+                constants.AddRange(ExtractArguments(methodCallExpression.Object, value));
+            }
 
             return constants;
         }


### PR DESCRIPTION
...ect

For example:

`sut.Given(_ => _.Foo.Bar.DoStuff())` will throw at the moment. This fixes that
