### PR TITLE
Added ShouldReport to ExecutableAttribute

### DIFF
--- a/TestStack.BDDfy.Tests/Scanner/ReflectiveScanner/WhenTestClassUsesExecutableAttributes.cs
+++ b/TestStack.BDDfy.Tests/Scanner/ReflectiveScanner/WhenTestClassUsesExecutableAttributes.cs
@@ -54,6 +54,9 @@ namespace TestStack.BDDfy.Tests.Scanner.ReflectiveScanner
 
             [But]
             public void IDontWantThisToBeTrue() { }
+
+            [Executable(ExecutionOrder.Assertion, "", ShouldReport = false)]
+            public void Executable() { }
         }
 
         [SetUp]
@@ -71,7 +74,7 @@ namespace TestStack.BDDfy.Tests.Scanner.ReflectiveScanner
         [Test]
         public void DecoratedMethodsAreReturned()
         {
-            Assert.That(_steps.Count, Is.EqualTo(10));
+            Assert.That(_steps.Count, Is.EqualTo(11));
         }
 
         [Test]
@@ -152,6 +155,22 @@ namespace TestStack.BDDfy.Tests.Scanner.ReflectiveScanner
             var step = _steps.Single(s => s.Title == "I dont want this to be true");
             Assert.That(step.ExecutionOrder, Is.EqualTo(ExecutionOrder.ConsecutiveAssertion));
             Assert.IsTrue(step.Asserts);
+        }
+
+        [Test]
+        public void ExecutableAttributesDefaultToShouldReport()
+        {
+            foreach (var step in _steps.Where(s => s.Title != "Executable"))
+            {
+                Assert.IsTrue(step.ShouldReport);
+            }
+        }
+
+        [Test]
+        public void CanPreventExecutableAttributesReporting()
+        {
+            var step = _steps.First(s => s.Title == "Executable");
+            Assert.IsFalse(step.ShouldReport);
         }
     }
 }

--- a/TestStack.BDDfy/Scanners/StepScanners/ExecutableAttribute/ExecutableAttribute.cs
+++ b/TestStack.BDDfy/Scanners/StepScanners/ExecutableAttribute/ExecutableAttribute.cs
@@ -9,11 +9,13 @@ namespace TestStack.BDDfy
         {
             ExecutionOrder = order;
             StepTitle = stepTitle;
+            ShouldReport = true;
         }
 
         public ExecutionOrder ExecutionOrder { get; private set; }
         public bool Asserts { get; set; }
         public string StepTitle { get; set; }
         public int Order { get; set; }
+        public bool ShouldReport { get; set; }
     }
 }

--- a/TestStack.BDDfy/Scanners/StepScanners/ExecutableAttribute/ExecutableAttributeStepScanner.cs
+++ b/TestStack.BDDfy/Scanners/StepScanners/ExecutableAttribute/ExecutableAttributeStepScanner.cs
@@ -37,12 +37,13 @@ namespace TestStack.BDDfy
                 stepTitle = new StepTitle(Configurator.Scanners.Humanize(candidateMethod.Name));
 
             var stepAsserts = IsAssertingByAttribute(candidateMethod);
+            var shouldReport = executableAttribute.ShouldReport;
 
             var runStepWithArgsAttributes = (RunStepWithArgsAttribute[])candidateMethod.GetCustomAttributes(typeof(RunStepWithArgsAttribute), true);
             if (runStepWithArgsAttributes.Length == 0)
             {
                 var stepAction = StepActionFactory.GetStepAction(candidateMethod, new object[0]);
-                yield return new Step(stepAction, stepTitle, stepAsserts, executableAttribute.ExecutionOrder, true, new List<StepArgument>())
+                yield return new Step(stepAction, stepTitle, stepAsserts, executableAttribute.ExecutionOrder, shouldReport, new List<StepArgument>())
                         {
                             ExecutionSubOrder = executableAttribute.Order
                         };
@@ -62,7 +63,7 @@ namespace TestStack.BDDfy
 
                 var stepAction = StepActionFactory.GetStepAction(candidateMethod, inputArguments);
                 yield return new Step(stepAction, new StepTitle(methodName), stepAsserts,
-                                      executableAttribute.ExecutionOrder, true, new List<StepArgument>())
+                                      executableAttribute.ExecutionOrder, shouldReport, new List<StepArgument>())
                         {
                             ExecutionSubOrder = executableAttribute.Order
                         };
@@ -80,6 +81,7 @@ namespace TestStack.BDDfy
                 stepTitle = Configurator.Scanners.Humanize(method.Name);
 
             var stepAsserts = IsAssertingByAttribute(method);
+            var shouldReport = executableAttribute.ShouldReport;
             var methodParameters = method.GetParameters();
 
             var inputs = new List<object>();
@@ -100,7 +102,7 @@ namespace TestStack.BDDfy
             }
 
             var stepAction = StepActionFactory.GetStepAction(method, inputs.ToArray());
-            yield return new Step(stepAction, new StepTitle(stepTitle), stepAsserts, executableAttribute.ExecutionOrder, true, new List<StepArgument>());
+            yield return new Step(stepAction, new StepTitle(stepTitle), stepAsserts, executableAttribute.ExecutionOrder, shouldReport, new List<StepArgument>());
         }
 
 


### PR DESCRIPTION
Sometimes it is convenient to prevent methods that have ExecutableAttributes from showing on the reports.