### PR TITLE
Enabled single example for example tables in HTML report

### DIFF
--- a/TestStack.BDDfy/Reporters/Html/ClassicReportBuilder.cs
+++ b/TestStack.BDDfy/Reporters/Html/ClassicReportBuilder.cs
@@ -175,7 +175,7 @@ namespace TestStack.BDDfy.Reporters.Html
         {
             using (OpenTag(string.Format("<div class='scenario'>"), HtmlTag.div))
             {
-                if (scenarioGroup.Count() == 1)
+                if (scenarioGroup.First().Example == null)
                     AddScenario(scenarioGroup.Single());
                 else
                     AddScenarioWithExamples(scenarioGroup);


### PR DESCRIPTION
I'm currently using BDDfy for my UI testing project and used the example table to increase readability. Eventhough example tables might not be designed for single examples, doing so was beneficial at least in my case. 