### PR TITLE
Test / fix for concurrency issue when using bddfy with parallel runners

### DIFF
--- a/src/TestStack.BDDfy.Tests/Concurrency/ParallelRunnerScenario.cs
+++ b/src/TestStack.BDDfy.Tests/Concurrency/ParallelRunnerScenario.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using TestStack.BDDfy.Tests.Stories;
+using Xunit;
+
+namespace TestStack.BDDfy.Tests.Concurrency
+{
+    public class ParallelRunnerScenario
+    {
+        [Fact]
+        public async Task CanHandleMultipleThreadsExecutingBddfyConcurrently()
+        {
+            try
+            {
+                await Task.WhenAll(
+                    Enumerable.Range(0, 100)
+                        .Select(_ => Task.Run(() => new DummyScenario().BDDfy<ParallelRunnerScenario>())));
+            }
+            catch (Exception e)
+            {
+                Assert.False(true, "Threw exception " + e);
+            }
+        }
+    }
+}

--- a/src/TestStack.BDDfy.Tests/TestStack.BDDfy.Tests.csproj
+++ b/src/TestStack.BDDfy.Tests/TestStack.BDDfy.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Arguments\ArgumentsProvidedForGiven.cs" />
     <Compile Include="Arguments\ArgumentsProvidedForThen.cs" />
     <Compile Include="Arguments\MultipleArgumentsProvidedForTheSameStep.cs" />
+    <Compile Include="Concurrency\ParallelRunnerScenario.cs" />
     <Compile Include="Configuration\EmptyScenario.cs" />
     <Compile Include="Configuration\SequentialKeyGeneratorTests.cs" />
     <Compile Include="Configuration\StepExecutorTests.cs" />
@@ -192,6 +193,7 @@
     <Content Include="TagsTests.TagsAreReportedInHtmlReport.approved.txt" />
     <Content Include="TagsTests.TagsAreReportedInTextReport.approved.txt" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
(see issue https://github.com/TestStack/TestStack.BDDfy/issues/222)

Pretty lo-fi solution but I've added a lock around the ContextLookup - seems to fix the issue.

Forgive not using Should.Throw - but it doesn't give me meaningful information about the exception in-order to verify it's the correct one. It just reports 'AggregateException' which is not much use.

