### PR TITLE
StepTitle Attribute - Retain original formatting flag

### DIFF
--- a/src/TestStack.BDDfy/StepTitleAttribute.cs
+++ b/src/TestStack.BDDfy/StepTitleAttribute.cs
@@ -4,20 +4,18 @@ namespace TestStack.BDDfy
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class StepTitleAttribute : Attribute
-    {
-        public StepTitleAttribute(string stepTitle)
-        {
-            StepTitle = stepTitle;
-        }
-        
-        public StepTitleAttribute(string stepTitle, bool includeInputsInStepTitle)
+    {        
+        public StepTitleAttribute(string stepTitle, bool includeInputsInStepTitle = false, bool autoFormatStepText = false)
         {
             IncludeInputsInStepTitle = includeInputsInStepTitle;
             StepTitle = stepTitle;
+            AutoFormatStepText = autoFormatStepText;
         }
 
         public string StepTitle { get; private set; }
 
         public bool? IncludeInputsInStepTitle { get; private set; }
+
+        public bool AutoFormatStepText { get; }
     }
 }


### PR DESCRIPTION
Property AutoFormatStepText on StepTitleAttribute. When false, will retain capitalisation / formatting of StepTitle, which is otherwise overwritten by Humanize.

Previously, if you annotate a method with a step title, BDDfy will still attempt to 'humanize' it. This will remove all capitalisation formatting and such.

This adds a flag to StepAttribute that users can choose if they want BDDfy to autoformat their step text, or if not, use their original formatting.