### PR TITLE
configure title function with configurator

### DIFF
--- a/src/TestStack.BDDfy.Tests/AssemblyInfo.cs
+++ b/src/TestStack.BDDfy.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/TestStack.BDDfy.Tests/Exceptions/ExceptionThrowingTest.cs
+++ b/src/TestStack.BDDfy.Tests/Exceptions/ExceptionThrowingTest.cs
@@ -52,7 +52,6 @@ namespace TestStack.BDDfy.Tests.Exceptions
 
         private Engine FluentScannerBddifier()
         {
-            BDDfy.Configuration.Configurator.Scanners.SetDefaultStepTitleCreatorFunction(null);
             return this.Given(s => s.Given())
                         .When(s => s.When())
                         .Then(s => s.Then())

--- a/src/TestStack.BDDfy.Tests/Exceptions/ExceptionThrowingTest.cs
+++ b/src/TestStack.BDDfy.Tests/Exceptions/ExceptionThrowingTest.cs
@@ -52,6 +52,7 @@ namespace TestStack.BDDfy.Tests.Exceptions
 
         private Engine FluentScannerBddifier()
         {
+            BDDfy.Configuration.Configurator.Scanners.SetDefaultStepTitleCreatorFunction(null);
             return this.Given(s => s.Given())
                         .When(s => s.When())
                         .Then(s => s.Then())

--- a/src/TestStack.BDDfy.Tests/Exceptions/ExceptionThrowingTest.cs
+++ b/src/TestStack.BDDfy.Tests/Exceptions/ExceptionThrowingTest.cs
@@ -6,9 +6,9 @@ namespace TestStack.BDDfy.Tests.Exceptions
 {
     public class ExceptionThrowingTest<T> where T : Exception, new()
     {
-        private static bool _givenShouldThrow;
-        private static bool _whenShouldThrow;
-        private static bool _thenShouldThrow;
+        private  bool _givenShouldThrow;
+        private  bool _whenShouldThrow;
+        private  bool _thenShouldThrow;
         Scenario _scenario;
 
         void Given()

--- a/src/TestStack.BDDfy.Tests/Exceptions/OtherExceptions/WhenGivenThrowsException.cs
+++ b/src/TestStack.BDDfy.Tests/Exceptions/OtherExceptions/WhenGivenThrowsException.cs
@@ -13,6 +13,7 @@ namespace TestStack.BDDfy.Tests.Exceptions.OtherExceptions
 
         private void ExecuteUsingFluentScanners()
         {
+            
             Should.Throw<Exception>(() => Sut.Execute(ThrowingMethods.Given, true));
         }
 

--- a/src/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
+++ b/src/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 using Shouldly;
 using TestStack.BDDfy.Configuration;
@@ -6,7 +7,7 @@ using Xunit;
 
 namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
 {
-    public class StepTitleTests
+    public class StepTitleTests:IDisposable
     {
         public StepTitleTests()
         {
@@ -192,6 +193,12 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
         private void ThenTitleHas(string result)
         {
             result.ShouldBe(_mutatedState);
+        }
+
+        public void Dispose()
+        {
+            Configurator.Scanners.SetDefaultStepTitleCreatorFunction(null);
+
         }
     }
 }

--- a/src/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
+++ b/src/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
@@ -36,7 +36,7 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
         {
             FooClass something = new FooClass();
             var context = TestContext.GetContext(something);
-            context.FluentScanner = new TestStack.BDDfy.FluentScanner<FooClass>(something);
+            new FluentStepBuilder<FooClass>(something);
             context.FluentScanner.SetCreateTitle((a, b, c, d, e) => new StepTitle("hallo"));
             var story = something
                .Given(_ => GivenWeMutateSomeState())
@@ -62,8 +62,8 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
 
             FooClass something = new FooClass();
             var context = TestContext.GetContext(something);
-            context.FluentScanner = new TestStack.BDDfy.FluentScanner<FooClass>(something);
-            context.FluentScanner.SetCreateTitle((a, b, c, d, e) => new StepTitle(e + " " + c.Name + " " + string.Join(",", d.Select(arg => arg.Value).ToArray())));
+            new FluentStepBuilder<FooClass>(something);
+           context.FluentScanner.SetCreateTitle((a, b, c, d, e) => new StepTitle(e + " " + c.Name + " " + string.Join(",", d.Select(arg => arg.Value).ToArray())));
             var story = something
                .Given(_ => GivenWeMutateSomeState())
                 .When(_ => something.Sub.SomethingHappens())

--- a/src/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
+++ b/src/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
+
 using Shouldly;
+
 using Xunit;
 
 namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
@@ -29,6 +31,58 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
             story.Scenarios.Single().Steps.ElementAt(6).Title.ShouldBe("And with foo arg");
         }
 
+        [Fact]
+        public void TitleFunctionCanBeOverriden()
+        {
+            FooClass something = new FooClass();
+            var context = TestContext.GetContext(something);
+            context.FluentScanner = new TestStack.BDDfy.FluentScanner<FooClass>(something);
+            context.FluentScanner.SetCreateTitle((a, b, c, d, e) => new StepTitle("hallo"));
+            var story = something
+               .Given(_ => GivenWeMutateSomeState())
+                .When(_ => something.Sub.SomethingHappens())
+                .And(_ => something.Sub.SomethingWithDifferentTitle())
+                .Then(_ => ThenTitleHas(AMethodCall()))
+                .And(_ => something.Sub.SomethingWithArg("foo"))
+                .And(_ => something.Sub.SomethingWithArg2("foo"))
+                .And(_ => something.Sub.SomethingWithArg3("foo"))
+                .BDDfy();
+
+            story.Scenarios.Single().Steps.ElementAt(2).Title.ShouldBe("hallo");
+            story.Scenarios.Single().Steps.ElementAt(3).Title.ShouldBe("hallo");
+            story.Scenarios.Single().Steps.ElementAt(4).Title.ShouldBe("hallo");
+            story.Scenarios.Single().Steps.ElementAt(5).Title.ShouldBe("hallo");
+            story.Scenarios.Single().Steps.ElementAt(6).Title.ShouldBe("hallo");
+        }
+
+        [Fact]
+        public void TitleFunctionCanBeOverridenAndUseParameters()
+        {
+            GivenWeMutateSomeState();
+
+            FooClass something = new FooClass();
+            var context = TestContext.GetContext(something);
+            context.FluentScanner = new TestStack.BDDfy.FluentScanner<FooClass>(something);
+            context.FluentScanner.SetCreateTitle((a, b, c, d, e) => new StepTitle(e + " " + c.Name + " " + string.Join(",", d.Select(arg => arg.Value).ToArray())));
+            var story = something
+               .Given(_ => GivenWeMutateSomeState())
+                .When(_ => something.Sub.SomethingHappens())
+                .And(_ => something.Sub.SomethingWithDifferentTitle())
+                .Then(_ => ThenTitleHas("Mutated state"))
+                .And(_ => something.Sub.SomethingWithArg("foo"))
+                .And(_ => something.Sub.SomethingWithArg2("foo2"))
+                .And(_ => something.Sub.SomethingWithArg3("foo3"))
+                .BDDfy();
+       
+            story.Scenarios.Single().Steps.ElementAt(0).Title.ShouldBe("Given GivenWeMutateSomeState ");
+            story.Scenarios.Single().Steps.ElementAt(1).Title.ShouldBe("When SomethingHappens ");
+            story.Scenarios.Single().Steps.ElementAt(2).Title.ShouldBe("And SomethingWithDifferentTitle ");
+            story.Scenarios.Single().Steps.ElementAt(3).Title.ShouldBe("Then ThenTitleHas Mutated state");
+            story.Scenarios.Single().Steps.ElementAt(4).Title.ShouldBe("And SomethingWithArg foo");
+            story.Scenarios.Single().Steps.ElementAt(5).Title.ShouldBe("And SomethingWithArg2 foo2");
+            story.Scenarios.Single().Steps.ElementAt(6).Title.ShouldBe("And SomethingWithArg3 foo3");
+        }
+
         public class FooClass
         {
             public FooClass()
@@ -43,7 +97,6 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
         {
             public void SomethingHappens()
             {
-                
             }
 
             [StepTitle("Different title")]

--- a/src/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
+++ b/src/TestStack.BDDfy.Tests/Scanner/FluentScanner/StepTitleTests.cs
@@ -68,7 +68,7 @@ namespace TestStack.BDDfy.Tests.Scanner.FluentScanner
                .Given(_ => GivenWeMutateSomeState())
                 .When(_ => something.Sub.SomethingHappens())
                 .And(_ => something.Sub.SomethingWithDifferentTitle())
-                .Then(_ => ThenTitleHas("Mutated state"))
+                .Then(_ => ThenTitleHas(AMethodCall()))
                 .And(_ => something.Sub.SomethingWithArg("foo"))
                 .And(_ => something.Sub.SomethingWithArg2("foo2"))
                 .And(_ => something.Sub.SomethingWithArg3("foo3"))

--- a/src/TestStack.BDDfy/BDDfyExtensions.cs
+++ b/src/TestStack.BDDfy/BDDfyExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using TestStack.BDDfy.Configuration;
 
 namespace TestStack.BDDfy
@@ -52,7 +53,9 @@ namespace TestStack.BDDfy
         /// <returns></returns>
         public static Story BDDfy(this object testObject, string scenarioTitle = null, [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
         {
-            return InternalLazyBDDfy(testObject, scenarioTitle ?? Configurator.Scanners.Humanize(caller)).Run();
+            var currentStory= InternalLazyBDDfy(testObject, scenarioTitle ?? Configurator.Scanners.Humanize(caller)).Run();
+            Configurator.Scanners.SetCustomStepTitleCreatorFunction(null);
+            return currentStory;
         }
 
         public static Engine LazyBDDfy(this object testObject, string scenarioTitle = null, [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
@@ -71,10 +74,13 @@ namespace TestStack.BDDfy
         public static Story BDDfy<TStory>(this object testObject, string scenarioTitle = null, [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
             where TStory : class
         {
-            return InternalLazyBDDfy(testObject, scenarioTitle ?? Configurator.Scanners.Humanize(caller), typeof(TStory)).Run();
+            Story currentStory= InternalLazyBDDfy(testObject, scenarioTitle ?? Configurator.Scanners.Humanize(caller), typeof(TStory)).Run();
+            Configurator.Scanners.SetCustomStepTitleCreatorFunction(null);
+            return currentStory;
         }
 
-        public static Engine LazyBDDfy<TStory>(this object testObject, string scenarioTitle = null, [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
+   
+       public static Engine LazyBDDfy<TStory>(this object testObject, string scenarioTitle = null, [System.Runtime.CompilerServices.CallerMemberName] string caller = null)
             where TStory : class
         {
             return InternalLazyBDDfy(testObject, scenarioTitle ?? Configurator.Scanners.Humanize(caller), typeof(TStory));
@@ -94,6 +100,7 @@ namespace TestStack.BDDfy
 
             return new Engine(storyScanner);
         }
+
 
         static IScanner GetReflectiveScanner(ITestContext testContext, string scenarioTitle = null, Type explicitStoryType = null)
         {

--- a/src/TestStack.BDDfy/Configuration/Scanners.cs
+++ b/src/TestStack.BDDfy/Configuration/Scanners.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace TestStack.BDDfy.Configuration
 {
     public class Scanners
     {
+        public readonly StepScannerFactory _ = new StepScannerFactory(() => new ExecutableAttributeStepScanner());
         private readonly StepScannerFactory _executableAttributeScanner = new StepScannerFactory(() => new ExecutableAttributeStepScanner());
         public StepScannerFactory ExecutableAttributeScanner { get { return _executableAttributeScanner; } }
 
@@ -15,6 +17,17 @@ namespace TestStack.BDDfy.Configuration
         public Scanners Add(Func<IStepScanner> stepScannerFactory)
         {
             _addedStepScanners.Add(stepScannerFactory);
+            return this;
+        }
+        internal Scanners SetCustomStepTitleCreatorFunction( Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customStepTitleCreatorFunction)
+        {
+            CustomStepTitleCreatorFunction= customStepTitleCreatorFunction;
+            return this;
+        }
+
+        public Scanners SetDefaultStepTitleCreatorFunction(Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> defaultStepTitleCreatorFunction)
+        {
+            DefaultStepTitleCreatorFunction = defaultStepTitleCreatorFunction;
             return this;
         }
 
@@ -35,6 +48,9 @@ namespace TestStack.BDDfy.Configuration
         }
 
         public Func<IStoryMetadataScanner> StoryMetadataScanner = () => new StoryAttributeMetadataScanner();
+
+        internal Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> CustomStepTitleCreatorFunction = null;
+        internal Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> DefaultStepTitleCreatorFunction = null;
 
         public Func<string, string> Humanize = NetToString.Convert;
     }

--- a/src/TestStack.BDDfy/Processors/TestRunner.cs
+++ b/src/TestStack.BDDfy/Processors/TestRunner.cs
@@ -24,20 +24,18 @@
                 }
 
                 var stepFailed = false;
+               
                 foreach (var executionStep in scenario.Steps)
                 {
                     executionStep.ResetTitle();
-                    
                     if (stepFailed && ShouldExecuteStepWhenPreviousStepFailed(executionStep))
                         break;
 
                     if (executor.ExecuteStep(executionStep) == Result.Passed)
-                     
                         continue;
-
+                  
                     if (!executionStep.Asserts)
                         break;
-
                     stepFailed = true;
                 }
             }

--- a/src/TestStack.BDDfy/Processors/TestRunner.cs
+++ b/src/TestStack.BDDfy/Processors/TestRunner.cs
@@ -1,5 +1,6 @@
 ﻿namespace TestStack.BDDfy.Processors
 {
+    using System;
     using System.Linq;
 
     public class TestRunner : IProcessor
@@ -25,10 +26,13 @@
                 var stepFailed = false;
                 foreach (var executionStep in scenario.Steps)
                 {
+                    executionStep.ResetTitle();
+                    
                     if (stepFailed && ShouldExecuteStepWhenPreviousStepFailed(executionStep))
                         break;
 
-                    if (executor.ExecuteStep(executionStep) == Result.Passed) 
+                    if (executor.ExecuteStep(executionStep) == Result.Passed)
+                     
                         continue;
 
                     if (!executionStep.Asserts)

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentApi.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentApi.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
- 
+using TestStack.BDDfy.Configuration;
+
 // ReSharper disable CheckNamespace
 // This is in BDDfy namespace to make its usage simpler
 namespace TestStack.BDDfy
@@ -9,60 +11,68 @@ namespace TestStack.BDDfy
 {
     public static class FluentStepScannerExtensions
     {
+
+        public static IFluentStepBuilder<TScenario> SetStepTitleFunction<TScenario>(this TScenario testObject, Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customStepTitleCreatorFunction)
+            where TScenario : class
+        {
+            Configurator.Scanners.SetCustomStepTitleCreatorFunction(customStepTitleCreatorFunction);
+            return new FluentStepBuilder<TScenario>(testObject);
+        }
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Expression<Action<TScenario>> step, string stepTextTemplate)
-            where TScenario: class
+           where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(step, stepTextTemplate);
         }
- 
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Expression<Action<TScenario>> step, bool includeInputsInStepTitle)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(step, includeInputsInStepTitle);
         }
- 
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Expression<Action<TScenario>> step)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(step);
         }
-        
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Expression<Func<TScenario, Task>> step, string stepTextTemplate)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(step, stepTextTemplate);
         }
- 
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Expression<Func<TScenario, Task>> step, bool includeInputsInStepTitle)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(step, includeInputsInStepTitle);
         }
- 
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Expression<Func<TScenario, Task>> step)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(step);
         }
- 
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Action step, string title)
             where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(step, title);
         }
- 
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Func<Task> step, string title)
             where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(step, title);
         }
- 
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, Expression<Func<ExampleAction>> action)
             where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).Given(action);
         }
- 
+
         public static IFluentStepBuilder<TScenario> Given<TScenario>(this TScenario testObject, string title)
             where TScenario : class
         {
@@ -70,53 +80,53 @@ namespace TestStack.BDDfy
         }
 
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, Expression<Action<TScenario>> step, string stepTextTemplate)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).When(step, stepTextTemplate);
         }
- 
+
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, Expression<Action<TScenario>> step, bool includeInputsInStepTitle)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).When(step, includeInputsInStepTitle);
         }
- 
+
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, Expression<Action<TScenario>> step)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).When(step);
         }
-        
+
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, Expression<Func<TScenario, Task>> step, string stepTextTemplate)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).When(step, stepTextTemplate);
         }
- 
+
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, Expression<Func<TScenario, Task>> step, bool includeInputsInStepTitle)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).When(step, includeInputsInStepTitle);
         }
- 
+
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, Expression<Func<TScenario, Task>> step)
-            where TScenario: class
+            where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).When(step);
         }
- 
+
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, Action step, string title)
             where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).When(step, title);
         }
- 
+
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, Func<Task> step, string title)
             where TScenario : class
         {
             return new FluentStepBuilder<TScenario>(testObject).When(step, title);
         }
- 
+
         public static IFluentStepBuilder<TScenario> When<TScenario>(this TScenario testObject, string title)
             where TScenario : class
         {
@@ -124,9 +134,12 @@ namespace TestStack.BDDfy
         }
     }
 
-    public interface IFluentStepBuilder<TScenario> where TScenario: class
+    public interface IFluentStepBuilder<TScenario> where TScenario : class
     {
+
         TScenario TestObject { get; }
+
+        IFluentStepBuilder<TScenario> SetStepTitleFunction(Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customStepTitleCreatorFunction);
 
         IFluentStepBuilder<TScenario> Given(Expression<Action<TScenario>> step, string stepTextTemplate);
 
@@ -308,7 +321,7 @@ namespace TestStack.BDDfy
         object TestObject { get; }
     }
 
-    public class FluentStepBuilder<TScenario> : IFluentStepBuilder<TScenario>, IFluentStepBuilder 
+    public class FluentStepBuilder<TScenario> : IFluentStepBuilder<TScenario>, IFluentStepBuilder
                                                 where TScenario : class
     {
         readonly FluentScanner<TScenario> scanner;
@@ -319,8 +332,8 @@ namespace TestStack.BDDfy
             var existingContext = TestContext.GetContext(TestObject);
             if (existingContext.FluentScanner == null)
                 existingContext.FluentScanner = new FluentScanner<TScenario>(testObject);
- 
-            scanner = (FluentScanner<TScenario>) existingContext.FluentScanner;
+            existingContext.FluentScanner.SetTitleFunction();
+            scanner = (FluentScanner<TScenario>)existingContext.FluentScanner;
         }
 
         public TScenario TestObject { get; private set; }
@@ -679,6 +692,12 @@ namespace TestStack.BDDfy
         public IFluentStepBuilder<TScenario> TearDownWith(string title)
         {
             scanner.AddStep(() => { }, title, false, ExecutionOrder.TearDown, false, "");
+            return this;
+        }
+
+        public IFluentStepBuilder<TScenario> SetStepTitleFunction(Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customStepTitleCreatorFunction)
+        {
+            Configurator.Scanners.SetCustomStepTitleCreatorFunction(customStepTitleCreatorFunction);
             return this;
         }
     }

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
@@ -36,7 +36,7 @@ namespace TestStack.BDDfy
     /// }
     /// </code>
     /// </example>
-    internal class FluentScanner<TScenario> : IFluentScanner
+    public class FluentScanner<TScenario> : IFluentScanner
         where TScenario : class
     {
         private readonly List<Step> _steps = new List<Step>();
@@ -44,15 +44,18 @@ namespace TestStack.BDDfy
         private readonly ITestContext _testContext;
         private readonly MethodInfo _fakeExecuteActionMethod;
         private Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> _createTitle;
-        internal FluentScanner(TScenario testObject)
-        {
-            _createTitle = CreateTitle;
+        public FluentScanner(TScenario testObject)
+        {     
             _testObject = testObject;
             _testContext = TestContext.GetContext(_testObject);
             _fakeExecuteActionMethod = typeof(FluentScanner<TScenario>).GetMethod("ExecuteAction", BindingFlags.Instance | BindingFlags.NonPublic);
+            _createTitle = CreateTitle;
         }
 
-
+        /// <summary>
+        /// string stepTextTemplate, bool includeInputsInStepTitle, MethodInfo methodInfo, StepArgument[] inputArguments, string stepPrefix
+        /// </summary>
+        /// <param name="customCreateTitle"></param>
         public void SetCreateTitle(Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customCreateTitle)
         {
             _createTitle = customCreateTitle;

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
@@ -45,21 +45,31 @@ namespace TestStack.BDDfy
         private readonly MethodInfo _fakeExecuteActionMethod;
         private Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> _createTitle;
         internal FluentScanner(TScenario testObject)
-        {     
-            _testObject = testObject;
+        {
+             _testObject = testObject;
             _testContext = TestContext.GetContext(_testObject);
             _fakeExecuteActionMethod = typeof(FluentScanner<TScenario>).GetMethod("ExecuteAction", BindingFlags.Instance | BindingFlags.NonPublic);
-            _createTitle = CreateTitle;
+
+            SetTitleFunction();
         }
 
-        /// <summary>
-        /// string stepTextTemplate, bool includeInputsInStepTitle, MethodInfo methodInfo, StepArgument[] inputArguments, string stepPrefix
-        /// </summary>
-        /// <param name="customCreateTitle"></param>
-        public void SetCreateTitle(Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customCreateTitle)
+        public void SetTitleFunction()
         {
-            _createTitle = customCreateTitle;
+            if (Configurator.Scanners.CustomStepTitleCreatorFunction != null)
+            {
+                _createTitle = Configurator.Scanners.CustomStepTitleCreatorFunction;
+            }
+            else
+          if (Configurator.Scanners.DefaultStepTitleCreatorFunction != null)
+            {
+                _createTitle = Configurator.Scanners.DefaultStepTitleCreatorFunction;
+            }
+            else
+            {
+                _createTitle = CreateTitle;
+            }
         }
+
         IScanner IFluentScanner.GetScanner(string scenarioTitle, Type explicitStoryType)
         {
             return new DefaultScanner(_testContext, new FluentScenarioScanner(_steps, scenarioTitle), explicitStoryType);

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
@@ -115,9 +115,8 @@ namespace TestStack.BDDfy
                 inputArguments = stepAction.ExtractArguments(_testObject).ToArray();
             }
 
-            var title = _createTitle(stepTextTemplate, includeInputsInStepTitle, GetMethodInfo(stepAction), inputArguments, stepPrefix);
-            var args = inputArguments.Where(s => !string.IsNullOrEmpty(s.Name)).ToList();
-            _steps.Add(new Step(stepAction, StepActionFactory.GetStepAction(action), _createTitle, stepTextTemplate,stepPrefix, includeInputsInStepTitle, GetMethodInfo, _testObject,title,  FixAsserts(asserts, executionOrder), FixConsecutiveStep(executionOrder), reports, args));
+              var args = inputArguments.Where(s => !string.IsNullOrEmpty(s.Name)).ToList();
+            _steps.Add(new Step(stepAction, StepActionFactory.GetStepAction(action), _createTitle, stepTextTemplate,stepPrefix, includeInputsInStepTitle, GetMethodInfo, _testObject,null,  FixAsserts(asserts, executionOrder), FixConsecutiveStep(executionOrder), reports, args));
         }
 
         public void AddStep(Expression<Action<TScenario>> stepAction, string stepTextTemplate, bool includeInputsInStepTitle, bool reports, ExecutionOrder executionOrder, bool asserts, string stepPrefix)
@@ -136,10 +135,8 @@ namespace TestStack.BDDfy
                 inputArguments = stepAction.ExtractArguments(_testObject).ToArray();
             }
 
-            var title = _createTitle(stepTextTemplate, includeInputsInStepTitle, GetMethodInfo(stepAction), inputArguments,
-                stepPrefix);
-            var args = inputArguments.Where(s => !string.IsNullOrEmpty(s.Name)).ToList();
-            _steps.Add(new Step(stepAction, stepTextTemplate, includeInputsInStepTitle, GetMethodInfo, stepPrefix,_createTitle, StepActionFactory.GetStepAction(action), title, FixAsserts(asserts, executionOrder),
+           var args = inputArguments.Where(s => !string.IsNullOrEmpty(s.Name)).ToList();
+            _steps.Add(new Step(stepAction, stepTextTemplate, includeInputsInStepTitle, GetMethodInfo, stepPrefix,_createTitle, StepActionFactory.GetStepAction(action), null, FixAsserts(asserts, executionOrder),
                 FixConsecutiveStep(executionOrder), reports, args));
         }
 

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
@@ -36,7 +36,7 @@ namespace TestStack.BDDfy
     /// }
     /// </code>
     /// </example>
-    public class FluentScanner<TScenario> : IFluentScanner
+    internal class FluentScanner<TScenario> : IFluentScanner
         where TScenario : class
     {
         private readonly List<Step> _steps = new List<Step>();
@@ -44,7 +44,7 @@ namespace TestStack.BDDfy
         private readonly ITestContext _testContext;
         private readonly MethodInfo _fakeExecuteActionMethod;
         private Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> _createTitle;
-        public FluentScanner(TScenario testObject)
+        internal FluentScanner(TScenario testObject)
         {     
             _testObject = testObject;
             _testContext = TestContext.GetContext(_testObject);

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/FluentScanner.cs
@@ -98,13 +98,14 @@ namespace TestStack.BDDfy
             AddStep(_ => compiledAction().Action(), expression, null, true, reports, executionOrder, asserts, stepPrefix);
         }
 
+
+
         [UsedImplicitly]
         [StepTitle("")]
         private void ExecuteAction(ExampleAction action)
         {
 
         }
-
         public void AddStep(Expression<Func<TScenario, Task>> stepAction, string stepTextTemplate, bool includeInputsInStepTitle, bool reports, ExecutionOrder executionOrder, bool asserts, string stepPrefix)
         {
             var action = stepAction.Compile();
@@ -116,7 +117,7 @@ namespace TestStack.BDDfy
 
             var title = _createTitle(stepTextTemplate, includeInputsInStepTitle, GetMethodInfo(stepAction), inputArguments, stepPrefix);
             var args = inputArguments.Where(s => !string.IsNullOrEmpty(s.Name)).ToList();
-            _steps.Add(new Step(StepActionFactory.GetStepAction(action), title, FixAsserts(asserts, executionOrder), FixConsecutiveStep(executionOrder), reports, args));
+            _steps.Add(new Step(stepAction, StepActionFactory.GetStepAction(action), _createTitle, stepTextTemplate,stepPrefix, includeInputsInStepTitle, GetMethodInfo, _testObject,title,  FixAsserts(asserts, executionOrder), FixConsecutiveStep(executionOrder), reports, args));
         }
 
         public void AddStep(Expression<Action<TScenario>> stepAction, string stepTextTemplate, bool includeInputsInStepTitle, bool reports, ExecutionOrder executionOrder, bool asserts, string stepPrefix)
@@ -138,7 +139,7 @@ namespace TestStack.BDDfy
             var title = _createTitle(stepTextTemplate, includeInputsInStepTitle, GetMethodInfo(stepAction), inputArguments,
                 stepPrefix);
             var args = inputArguments.Where(s => !string.IsNullOrEmpty(s.Name)).ToList();
-            _steps.Add(new Step(StepActionFactory.GetStepAction(action), title, FixAsserts(asserts, executionOrder),
+            _steps.Add(new Step(stepAction, stepTextTemplate, includeInputsInStepTitle, GetMethodInfo, stepPrefix,_createTitle, StepActionFactory.GetStepAction(action), title, FixAsserts(asserts, executionOrder),
                 FixConsecutiveStep(executionOrder), reports, args));
         }
 

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/IFluentScanner.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/IFluentScanner.cs
@@ -6,6 +6,6 @@ namespace TestStack.BDDfy
     public interface IFluentScanner
     {
         IScanner GetScanner(string scenarioTitle, Type explicitStoryType);
-        void SetCreateTitle(Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customCreateTitle);
+        void SetTitleFunction();
     }
 }

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/IFluentScanner.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/IFluentScanner.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Reflection;
 
 namespace TestStack.BDDfy
 {
     public interface IFluentScanner
     {
         IScanner GetScanner(string scenarioTitle, Type explicitStoryType);
+        void SetCreateTitle(Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customCreateTitle);
     }
 }

--- a/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/StepTitleExtension.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/Fluent/StepTitleExtension.cs
@@ -1,0 +1,15 @@
+﻿//using System;
+//using System.Collections.Generic;
+//using System.Reflection;
+//using System.Text;
+
+//namespace TestStack.BDDfy.Scanners.StepScanners.Fluent
+//{
+//  public static  class StepTitleExtension
+//    {
+//        public void void SetCreateTitle(this IFluentScanner fluentScanner,Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> customCreateTitle);
+//        {
+//        fluentScanner.s
+//    }
+//    }
+//}

--- a/src/TestStack.BDDfy/Scanners/StepScanners/SetTitleExtensionMethod.cs
+++ b/src/TestStack.BDDfy/Scanners/StepScanners/SetTitleExtensionMethod.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestStack.BDDfy.Scanners.StepScanners
+{
+ public static class SetTitleExtensionMethod
+    {
+
+    }
+}

--- a/src/TestStack.BDDfy/Step.cs
+++ b/src/TestStack.BDDfy/Step.cs
@@ -1,19 +1,31 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
 using TestStack.BDDfy.Configuration;
-
+using System.Linq;
 namespace TestStack.BDDfy
 {
     public class Step
     {
-        private readonly StepTitle _title;
+        private StepTitle _title;
+        private LambdaExpression _stepAction;
+        private Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> _createTitle;
+        private string _stepTextTemplate;
+        private string _stepPrefix;
+        private bool _includeInputsInStepTitle;
+        private Func<LambdaExpression, MethodInfo> _getMethodInfo;
+        private object _testObject;
+        private bool _reports;
+
 
         public Step(
             Func<object, object> action,
             StepTitle title,
             bool asserts,
             ExecutionOrder executionOrder,
-            bool shouldReport, 
+            bool shouldReport,
             List<StepArgument> arguments)
         {
             Id = Configurator.IdGenerator.GetStepId();
@@ -36,6 +48,55 @@ namespace TestStack.BDDfy
             Result = Result.NotExecuted;
             Action = step.Action;
             Arguments = step.Arguments;
+        }
+
+        public Step(LambdaExpression stepAction, Func<object, object> action, Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> createTitle, string stepTextTemplate, string stepPrefix, bool includeInputsInStepTitle, Func<LambdaExpression, MethodInfo> getMethodInfo, object testObject, string title, bool assert, ExecutionOrder executionOrder, bool shouldReport, List<StepArgument> args)
+        {
+            _stepAction = stepAction;
+            Action = action;
+            _createTitle = createTitle;
+            _stepTextTemplate = stepTextTemplate;
+            _includeInputsInStepTitle = includeInputsInStepTitle;
+            _getMethodInfo = getMethodInfo;
+            _testObject = testObject;
+            this.Asserts = assert;
+            _title = new StepTitle(title);
+            ExecutionOrder = executionOrder;
+            ShouldReport = shouldReport;
+            Arguments = args;
+            _stepPrefix = stepPrefix;
+        }
+
+        public Step(LambdaExpression stepAction, string stepTextTemplate, bool includeInputsInStepTitle, Func<LambdaExpression, MethodInfo> getMethodInfo, string stepPrefix, Func<string, bool, MethodInfo, StepArgument[], string, StepTitle> createTitle, Func<object, object> action, StepTitle title, bool assert, ExecutionOrder executionOrder, bool shouldReport, List<StepArgument> args)
+        {
+            _stepAction = stepAction;
+            _stepTextTemplate = stepTextTemplate;
+            _includeInputsInStepTitle = includeInputsInStepTitle;
+            _getMethodInfo = getMethodInfo;
+            _stepPrefix = stepPrefix;
+            Action = action;
+            _title = title;
+            Asserts = assert;
+            ExecutionOrder = executionOrder;
+            ShouldReport = shouldReport;
+            Arguments = args;
+            _createTitle = createTitle;
+            
+        }
+
+        public void ResetTitle()
+        {
+            if (_stepAction != null)
+            {
+                var action = _stepAction.Compile();
+                var inputArguments = new StepArgument[0];
+                if (_includeInputsInStepTitle)
+                {
+                    inputArguments = _stepAction.ExtractArguments(_testObject).ToArray();
+                }
+
+                _title = _createTitle(_stepTextTemplate, _includeInputsInStepTitle, _getMethodInfo(_stepAction), inputArguments, _stepPrefix);
+            }
         }
 
         public string Id { get; private set; }

--- a/src/TestStack.BDDfy/Step.cs
+++ b/src/TestStack.BDDfy/Step.cs
@@ -60,7 +60,6 @@ namespace TestStack.BDDfy
             _getMethodInfo = getMethodInfo;
             _testObject = testObject;
             this.Asserts = assert;
-            _title = new StepTitle(title);
             ExecutionOrder = executionOrder;
             ShouldReport = shouldReport;
             Arguments = args;
@@ -107,6 +106,14 @@ namespace TestStack.BDDfy
         {
             get
             {
+                if (_title == null)
+                {
+                    ResetTitle();
+                }
+                if (_title == null)
+                {
+                 return  string.Empty;
+                }
                 return _title.ToString();
             }
         }


### PR DESCRIPTION
 I added 
SetDefaultStepTitleCreatorFunction and SetCustomStepTitleCreatorFunction

the default is always used the SetCustomStepTitleCreatorFunction can be set during tests. 
it is configurable  by configurator.scanner
I didn't used the _addedStepScanners factory since  it is not possible to  do all the step titles at once. 
The title will change during the execution of the steps. Doinig it like this seems more appropriate